### PR TITLE
Changes to `scope` and `data`

### DIFF
--- a/specifications/properties/hints/container.md
+++ b/specifications/properties/hints/container.md
@@ -17,12 +17,6 @@ None
 - `object`
 - `array`
 
-## Format Rules
-
-If the value is present, it must comply with the following rules:
-
-- if the value is an object, it MAY have a `scope` property whose value specifies the content realm intended for display. If present, the value MUST comply with the rules defined for [realm URI](../../../realm/).
-
 ## Examples
 
 ### Object Value

--- a/specifications/properties/hints/content.md
+++ b/specifications/properties/hints/content.md
@@ -21,7 +21,7 @@ None
 If the value is present, it must comply with the following rules:
 
 - MUST be an object.
-- MUST have an `src` property for remote content or a `data` property for inline content.
+- MAY have an `src` property for remote content or a `data` property for inline content.
 - SHOULD have an `alt` property for alternate text to be displayed if the content cannot be displayed or if the user cannot view it.
 - MAY have a `scope` property whose value specifies the content realm intended for display. If present, the value MUST comply with the rules defined for [realm URI](../../../realm/).
 - MAY have a `rel` property whose value specifies the relationship between the document containing the content and the destination resource, as described in [RFC 5988](../../../references/#rfc-5988).
@@ -32,18 +32,26 @@ If the value is present, it must comply with the following rules:
 
 If the value has an `src` property:
 
-- the `src` property MUST be a valid [URI](../../../#uri).
-- the value MAY have a `type` property whose value must be a valid [media type name](../../../references/#rfc-6838) to indicate the expected media type of the content.
-- the value MUST NOT have `data` or `encoding` properties.
+- `src` MUST be a valid [URI](../../../#uri).
+- MAY have a `type` property whose value must be a valid 
+  [media type name](../../../references/#rfc-6838) to indicate the expected 
+  media type of the content.
+- MUST NOT have `data` or `encoding` properties.
 
 ### `data` present
 
 If the value has a `data` property:
 
-- the `data` property MUST be a string representing the content to be embedded.
-- the value MUST have a `type` property whose value must be a valid [media type name](../../../references/#rfc-6838) to indicate the media type of the content encoded in the `data` property.
-- the value MAY have an `encoding` property whose value MUST be `utf-8` or `base64`. If not present, the value is `utf-8`.
-- the value MUST NOT have an `src` property.
+- MUST have a `type` property whose value must be a valid 
+  [media type name](../../../references/#rfc-6838) to indicate the media type of
+  the content encoded in the `data` property.
+- if `type` is `application/json` or a variant of `application/json`, 
+  `data` MAY be an object or an array; otherwise, `data` MUST be a string 
+  representing the content to be embedded.
+- if `data` is a string, MAY have an `encoding` property 
+  whose value MUST be `utf-8` or `base64`. If not present, the `encoding` 
+  is `utf-8`.
+- MUST NOT have an `src` property.
 
 ## Examples
 
@@ -61,11 +69,53 @@ If the value has a `data` property:
 
 ### `data` present
 
+#### UTF-8 String
+
 ```json
 {
   "data": "# Review of Fletch\n##Pros\n\nToo many to list.\n##Cons\n\nNone!",
   "type": "text/markdown",
   "alt": "Movie Review of Fletch",
+  "spec": {
+    "hints": [ "content" ]
+  }
+}
+```
+
+#### Base64 String
+
+```json
+{
+  "data": "WW91IHRhbGtpbmcgdG8gbWU/IC0tIFRheGkgRHJpdmVy",
+  "encoding": "base64",
+  "type": "text/plain",
+  "alt": "Movie Quote",
+  "spec": {
+    "hints": [ "content" ]
+  }
+}
+```
+
+#### JSON Content
+
+```json
+{
+  "data": {
+    "base": "http://example.com/",
+    "realm": "http://example.com/movie-quotes/",
+    "value": [
+      "There's no crying in baseball! -- Tom Hanks, A League of Their Own",
+      "Mrs. Robinson, you're trying to seduce me. Aren't you? -- Dustin Hoffman, The Graduate",
+      "Donny you're out of your element! -- John Goodman, The Big Lebowski"
+    ],
+    "spec": {
+      "hints": [ "list", "container" ],
+      "children": {
+        "hints": [ "text" ]
+      }
+    }
+  },
+  "type": "application/lynx+json",
   "spec": {
     "hints": [ "content" ]
   }

--- a/specifications/properties/hints/form.md
+++ b/specifications/properties/hints/form.md
@@ -21,7 +21,6 @@ None
 If the value is present, it must comply with the following rules:
 
 - MUST be an object.
-- MAY have a `scope` property whose value specifies the content realm intended for display. If present, the value MUST comply with the rules defined for [realm URI](../../../realm/).
 - MAY contain other properties.
 
 ## Examples

--- a/specifications/properties/hints/link.md
+++ b/specifications/properties/hints/link.md
@@ -21,14 +21,39 @@ None
 If the value is present, it must comply with the following rules:
 
 - MUST be an object.
-- MUST have an `href` property whose value is a valid [URI](../../../#uri).
-- MAY have a `type` property whose value must be a valid [media type name](../../../references/#rfc-6838) to indicate the expected media type of the content.
-- MAY have a `scope` property whose value specifies the content realm intended for display. If present, the value MUST comply with the rules defined for [realm URI](../../../realm/).
+- MUST have an `href` property for remote content or a `data` property for inline content.
 - MAY have a `rel` property whose value specifies the relationship between the document containing the link and the destination resource, as described in [RFC 5988](../../../references/#rfc-5988).
 - MAY have a `follow` property whose value must be a positive number representing the number of milliseconds the user agent should wait before following the link on behalf of the user.
 - MAY contain other properties.
 
+### `href` present
+
+If the value has an `href` property:
+
+- `href` MUST be a valid [URI](../../../#uri).
+- MAY have a `type` property whose value must be a valid 
+  [media type name](../../../references/#rfc-6838) to indicate the expected 
+  media type of the content.
+- MUST NOT have `data` or `encoding` properties.
+
+### `data` present
+
+If the value has a `data` property:
+
+- MUST have a `type` property whose value must be a valid 
+  [media type name](../../../references/#rfc-6838) to indicate the media type of
+  the content encoded in the `data` property.
+- if `type` is `application/json` or a variant of `application/json`, 
+  `data` MAY be an object or an array; otherwise, `data` MUST be a string 
+  representing the content to be embedded.
+- if `data` is a string, MAY have an `encoding` property 
+  whose value MUST be `utf-8` or `base64`. If not present, `encoding` 
+  is `utf-8`.
+- MUST NOT have an `href` property.
+
 ## Examples
+
+### `href` present
 
 ```json
 {
@@ -46,6 +71,59 @@ If the value is present, it must comply with the following rules:
 }
 ```
 
+### `data` present
+
+#### UTF-8 String
+
+```json
+{
+  "data": "# Review of Fletch\n##Pros\n\nToo many to list.\n##Cons\n\nNone!",
+  "type": "text/markdown",
+  "spec": {
+    "hints": [ "link" ]
+  }
+}
+```
+
+#### Base64 String
+
+```json
+{
+  "data": "WW91IHRhbGtpbmcgdG8gbWU/IC0tIFRheGkgRHJpdmVy",
+  "encoding": "base64",
+  "type": "text/plain",
+  "spec": {
+    "hints": [ "link" ]
+  }
+}
+```
+
+#### JSON Content
+
+```json
+{
+  "data": {
+    "base": "http://example.com/",
+    "realm": "http://example.com/movie-quotes/",
+    "value": [
+      "Fasten your seatbelts, it's going to be a bumpy night. -- Bette Davis, All About Eve",
+      "I'll have what she's having. -- Estelle Reiner, When Harry Met Sally",
+      "Plastics. -- Walter Brooke, The Graduate"
+    ],
+    "spec": {
+      "hints": [ "list", "container" ],
+      "children": {
+        "hints": [ "text" ]
+      }
+    }
+  },
+  "type": "application/lynx+json",
+  "spec": {
+    "hints": [ "link" ]
+  }
+}
+```
+
 ## Authoring Rules
 
 None
@@ -53,8 +131,8 @@ None
 ## User Agent Rules
 
 - The user agent MUST provide the user with a control to interact with the hyperlink in order to follow it.
-- If the user follows the hyperlink, then the user agent MUST fetch the target identified by the `href` using the default retrieval action for the protocol (e.g. GET for HTTP).
-- The user agent SHOULD display or make the `href` accessible to the user so he/she can consider its value prior to following the hyperlink.
+- If `href` is present, when the user follows the hyperlink, then the user agent MUST fetch the target identified by the `href` using the default retrieval action for the protocol (e.g. GET for HTTP).
+- If `href` is present, the user agent SHOULD display or make the `href` accessible to the user so he/she can consider its value prior to following the hyperlink.
 - If the link contains a `follow` property, the user agent MUST wait the specified number of milliseconds and then MUST follow the hyperlink.
 
 ## User Agent Considerations

--- a/specifications/properties/hints/submit.md
+++ b/specifications/properties/hints/submit.md
@@ -24,7 +24,9 @@ If the value is present, it must comply with the following rules:
 - MUST have an `action` property whose value is a valid [URI](../../../#uri).
 - MAY have a `method` property indicating the protocol method used to submit the form data.
 - MAY have an `enctype` property indicating how the form data is to be encoded. If not present, the default value is `application/x-www-form-urlencoded`.
-- MAY have a `scope` property whose value specifies the content realm intended for display. If present, the value MUST comply with the rules defined for [realm URI](../../../realm/).
+- MAY have a `type` property whose value must be a valid 
+  [media type name](../../../references/#rfc-6838) to indicate the expected 
+  media type of the content.
 - MAY have a `rel` property whose value specifies the relationship between the document containing the submit and the destination resource, as described in [RFC 5988](../../../references/index.md#rfc-5988).
 - MAY have a `send` property whose value must be "change", indicating that the user agent should invoke the submit on behalf of the user when the user changes an input value.
 - MAY contain other properties.


### PR DESCRIPTION
This is an attempt to improve the consistency of sub-windows. Previously
we had two flavors of sub-windows: `content` objects and any container
with a `scope`. This proposal removes `scope` from containers, leaving
`content` objects as the only form of sub-window in the lynx media type.

In order to support a sub-window with no initial content, this change
also removes the requirement for an `src` or `data` value. A sub-window
can start out with no content.

In order to support this change with as little disruption as possible,
we're adding a new form of embedded data. Previously, the `data`
property allowed embedding inline content with a string (encoded
as either utf-8 or base64). This change adds the ability to embed a
JSON document as an object or array rather than encoding it as a
string. We're also adding support for inline `data` to link values
as an alternative to an `href`.