### PR TITLE
Added `form` and `content` as `complement` Base

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,6 +13,7 @@
         * [Label](specifications/properties/hints/label.md)
         * [Content](specifications/properties/hints/content.md)
         * [Image](specifications/properties/hints/image.md)
+        * [Emblem](specifications/properties/hints/emblem.md)
       * Containers
         * [Container](specifications/properties/hints/container.md)
         * [Header](specifications/properties/hints/header.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -16,6 +16,7 @@
       * Containers
         * [Container](specifications/properties/hints/container.md)
         * [Header](specifications/properties/hints/header.md)
+        * [Footer](specifications/properties/hints/footer.md)
         * [Complement](specifications/properties/hints/complement.md)
         * [Group](specifications/properties/hints/group.md)
         * [List](specifications/properties/hints/list.md)

--- a/specifications/properties/hints/complement.md
+++ b/specifications/properties/hints/complement.md
@@ -11,6 +11,8 @@ A `complement` hint describes a value that is secondary in nature to the sibling
 ## Related Hints
 
 - `["complement", "container"]`
+- `["complement", "form"]`
+- `["complement", "content"]`
 
 ## Synonyms
 

--- a/specifications/properties/hints/emblem.md
+++ b/specifications/properties/hints/emblem.md
@@ -1,0 +1,101 @@
+# Emblem Hint
+
+## Name
+
+`http://lynx-json.org/emblem`
+
+## Meaning
+
+An `emblem` hint describes a value providing a symbolic representation of another value.
+
+## Related Hints
+
+- `[ "emblem", "text" ]`
+- `[ "emblem", "content" ]`
+
+## Format Rules
+
+None
+
+## Examples
+
+### Text
+
+```json
+{
+  "value": {
+    "emblem": {
+      "value": "🐶",
+      "spec": {
+        "hints": [
+          "emblem",
+          "text"
+        ]
+      }
+    },
+    "animal": {
+      "value": "Dog",
+      "spec": {
+        "hints": [
+          "text"
+        ]
+      }
+    }
+  },
+  "spec": {
+    "hints": [ "container" ]
+  }
+}
+```
+
+### Content
+
+```json
+{
+  "value": {
+    "label": {
+      "value": {
+        "src": "./dog-image.jpg",
+        "type": "image/jpeg",
+        "alt": "An Image of a Dog",
+        "height": 40,
+        "width": 40
+      },
+      "spec": {
+        "hints": [
+          "emblem",
+          "image",
+          "content"
+        ]
+      }
+    },
+    "animal": {
+      "value": "Dog",
+      "spec": {
+        "hints": [
+          "text"
+        ]
+      }
+    }
+  },
+  "spec": {
+    "hints": [ "container" ]
+  }
+}
+```
+
+## Authoring Rules
+
+None
+
+## Authoring Considerations
+
+None
+
+## User Agent Rules
+
+None
+
+## User Agent Considerations
+
+None

--- a/specifications/properties/hints/footer.md
+++ b/specifications/properties/hints/footer.md
@@ -1,0 +1,81 @@
+# Footer Hint
+
+## Name
+
+`http://lynx-json.org/footer`
+
+## Meaning
+
+A `footer` hint describes a value that concludes other content.
+
+## Related Hints
+
+- `[ "footer", "container" ]`
+
+## Synonyms
+
+None
+
+## Format Rules
+
+None
+
+## Example
+
+```json
+{
+  "header": {
+    "label": "Review of Fletch"
+  },
+  "description": "Fletch is fantastic!",
+  "footer": {
+    "copyright": "Copyright © 1985"
+  },
+  "spec": {
+    "hints": [ "container" ],
+    "children": [
+        {
+            "name": "header",
+            "hints": [ "header", "container" ],
+            "children": [
+              {
+                "name": "label",
+                "hints": [ "label", "text" ]
+              }
+            ]
+        },
+      {
+"name": "description",
+"hints": [ "text" ]
+      },
+      {
+          "name": "footer",
+          "hints": [ "footer", "container" ],
+          "children": [
+            {
+              "name": "copyright",
+              "hints": [ "label", "text" ]
+            }
+          ]
+      }
+    ]
+  }
+}
+
+```
+
+## Authoring Rules
+
+None
+
+## Authoring Considerations
+
+None
+
+## User Agent Rules
+
+None
+
+## User Agent Considerations
+
+In order for a footer to effectively conclude content, the user agent should display the footer in a way that accomplishes that goal. For example, in print, a footer often stands on its own line and is often preceded by a rule.

--- a/specifications/properties/hints/label.md
+++ b/specifications/properties/hints/label.md
@@ -12,7 +12,6 @@ A `label` hint describes a value that represents a distinguishing name for anoth
 
 - `[ "label", "text" ]`
 - `[ "label", "content" ]`
-- `[ "label", "container" ]`
 
 ## Synonyms
 
@@ -74,53 +73,6 @@ None
     },
     "firstName": {
       "value": "",
-      "spec": {
-        "hints": [
-          "text"
-        ],
-        "labeledBy": "label"
-      }
-    }
-  },
-  "spec": {
-    "hints": [ "container" ]
-  }
-}
-```
-
-### Container
-
-```json
-{
-  "value": {
-    "label": {
-      "value": {
-        "heading": {
-          "value": "The Hateful Eight",
-          "spec": {
-            "hints": [ "text" ]
-          }
-        },
-        "subHeading": {
-          "value": "No One Comes Up Here Without a Damn Good Reason",
-          "spec": {
-            "hints": [ "text" ]
-          }
-        }
-      },
-      "spec": {
-        "hints": [
-          "label",
-          "container"
-        ],
-        "children": [
-          { "name": "heading" },
-          { "name": "subHeading" }
-        ]
-      }
-    },
-    "synopsis": {
-      "value": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
       "spec": {
         "hints": [
           "text"


### PR DESCRIPTION
Previously we documented the Related Hints for `complement`
as:

```
[ "complement", "container" ]
```

Since forms and content objects are semantically just containers,
it seems reasonable to allow them as a base for `complement`. The
requirement seems common and this will reduce arbitrary nesting.