### PR TITLE
Remove Object Value From Input Property

### DIFF
--- a/processes/submitting_form_data.md
+++ b/processes/submitting_form_data.md
@@ -14,7 +14,7 @@ To prepare a form data set:
 For each _input_ in _inputs_:
 
 - Let _result_ be a tuple having _name_ and _value_ components.
-  - Let _name_ be the value of the _input_ specification property's `name` property, if it exists. Otherwise, let _name_ be the `name` of the input value, if it exists. Otherwise, let _name_ be the `name` of the input value's first named ancestor.
+  - Let _name_ be the value of the _input_ specification property's value, if it is a string. Otherwise, let _name_ be the `name` of the input value, if it exists. Otherwise, repeat the process for each ancestor until _name_ has been resolved.
   - Let _value_ be a tuple having _data_ and _type_ components.
     - For `text` inputs, let _data_ be the value's JSON value (as defined in [RFC 4627, Section 2.1](../references/index.md#rfc-4627)) if the value is not `null` or `undefined`; otherwise, let _data_ be an empty string. Let _type_ be an empty string.
     - For `content` inputs, let _data_ and _type_ be the value of the `content` value's `data` and `type` properties.

--- a/specifications/properties/input.md
+++ b/specifications/properties/input.md
@@ -14,7 +14,6 @@ The `input` property is OPTIONAL. If present, its value:
 
 - MAY be `true`.
 - MAY be a string to indicate the name of the form data value.
-- MAY be an object with a `name` property whose value MUST be a string to indicate the name of the form data value.
 
 ## Examples
 
@@ -45,24 +44,6 @@ The `input` property is OPTIONAL. If present, its value:
       {
         "name": "rating",
         "input": "mpaa-rating",
-        "hints": [ "text" ]
-      }
-    ]
-  }
-}
-```
-
-```json
-{
-  "rating": "PG",
-  "spec": {
-    "hints": [ "form" ],
-    "children": [
-      {
-        "name": "rating",
-        "input": {
-          "name": "mpaa-rating"
-        },
         "hints": [ "text" ]
       }
     ]


### PR DESCRIPTION
Just as with the `hints` property, removing the allowed object value
from the `input` property.