### PR TITLE
Normalize sections for base hints

### DIFF
--- a/specifications/properties/hints/container.md
+++ b/specifications/properties/hints/container.md
@@ -17,6 +17,10 @@ None
 - `object`
 - `array`
 
+## Format Rules
+
+None
+
 ## Examples
 
 ### Object Value

--- a/specifications/properties/hints/emblem.md
+++ b/specifications/properties/hints/emblem.md
@@ -13,6 +13,10 @@ An `emblem` hint describes a value providing a symbolic representation of anothe
 - `[ "emblem", "text" ]`
 - `[ "emblem", "content" ]`
 
+## Synonyms
+
+None
+
 ## Format Rules
 
 None


### PR DESCRIPTION
This change is to normalize the content sections for hint documents.